### PR TITLE
Make license identifier SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
   "bugs": {
     "url": "https://github.com/dcporter/didyoumean.js/issues"
   },
-  "license": "Apache"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
`package.json` uses SPDX identifiers for licenses, see: https://spdx.org/licenses/

The problem with _not_ using an SPDX identifier is that automatic license detection systems (such as GitLab's License Compliance) fails to understand which license you're using.

I know there's been zero changes to the library in many years, but apparently [tailwind](https://tailwindcss.com/) has this as a dependency, so users of tailwind need to deal with your license :)